### PR TITLE
Us5 inproceedings

### DIFF
--- a/src/repositories/inproceedings_repository.py
+++ b/src/repositories/inproceedings_repository.py
@@ -4,9 +4,9 @@ from config import db
 def create_inproceedings(title, author, booktitle, year, editor, volume, number, series, pages, address, month, organization, publisher):
     sql = """
         INSERT INTO inproceedings
-            (author, title, booktitle, year, volume, number, series, pages, address, month, organization, publisher)
+            (author, title, booktitle, year, editor, volume, number, series, pages, address, month, organization, publisher)
         VALUES
-            (:author, :title, :booktitle, :year, :volume, :number, :series, :pages, :address, :month, :organization, :publisher)
+            (:author, :title, :booktitle, :year, :editor, :volume, :number, :series, :pages, :address, :month, :organization, :publisher)
         RETURNING id
     """
     params = {

--- a/src/services/inproceedings_service.py
+++ b/src/services/inproceedings_service.py
@@ -4,9 +4,15 @@ from validators import (
     validate_numeric,
     validate_author,
     validate_title,
+    validate_booktitle,
     validate_year,
+    validate_series,
     validate_pages,
+    validate_address,
     validate_month,
+    validate_organization,
+    validate_publisher,
+    validate_editor
 )
 
 class UserInputError(Exception):
@@ -36,7 +42,7 @@ def validate_inproceedings(author, title, booktitle, year, editor=None, volume=N
         UserInputError: If any field fails validation.
 
     Returns:
-        int: The ID of the created article.
+        int: The ID of the created inproceedings.
     """
     try:
         # Month mapping for numeric and abbreviated month inputs
@@ -57,24 +63,24 @@ def validate_inproceedings(author, title, booktitle, year, editor=None, volume=N
         validate_title(title)
         
         validate_required_field(booktitle, "Booktitle")
-        validate_title(booktitle)
+        validate_booktitle(booktitle)
         
         validate_required_field(year, "Year")
         validate_year(year)
         
         # Validate optional fields
         if editor:
-            validate_author(editor)
+            validate_editor(editor)
         if volume:
             validate_numeric(volume, "Volume")
         if number:
             validate_numeric(number, "Issue")
         if series:
-            validate_title(series)
+            validate_series(series)
         if pages:
             validate_pages(pages)
         if address:
-            validate_title(address)
+            validate_address(address)
         if month:
             # Normalize month input
             if month.isdigit():
@@ -96,9 +102,9 @@ def validate_inproceedings(author, title, booktitle, year, editor=None, volume=N
             validate_month(month)  # Validate the normalized month
         
         if organization:
-            validate_title(organization)
+            validate_organization(organization)
         if publisher:
-            validate_title(publisher)
+            validate_publisher(publisher)
 
         # Delegate to repository for database operations
         return inproceedings_repository.create_inproceedings(

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -142,9 +142,10 @@ Reference app
         <div class="modal-body">
           <h4>{{ inproceedings.title }}</h4>
           <p>
-            <b>Author:</b>  {{ inproceedings.author }}</br>
+            <b>Author(s):</b>  {{ inproceedings.author }}</br>
             <b>Published:</b>  {% if inproceedings.month %}{{ inproceedings.month }}{% endif %} {{ inproceedings.year }}</br>
             <b>Book title:</b>  {{ inproceedings.booktitle }} </br>
+            <b>Editor(s):</b>  {% if inproceedings.editor %}{{ inproceedings.editor }}{% endif %} </br>
             <b>Volume:</b>  {% if inproceedings.volume %}{{ inproceedings.volume }}{% endif %} </br>
             <b>Number:</b>  {% if inproceedings.number %}{{ inproceedings.number }}{% endif %} </br>
             <b>Pages:</b> {% if inproceedings.pages %}{{ inproceedings.pages }}{% endif %} </br>

--- a/src/templates/inproceedings.html
+++ b/src/templates/inproceedings.html
@@ -82,7 +82,7 @@ Reference app
                 {{ form.series.label(class="form-label") }}
                 {{ form.series(class="form-control") }}
                 <small id="seriesHelpInLine" class="text-muted">
-                    Optional. Must be 5-255 characters long if not left empty. Can contain letters, numbers, spaces, and punctuation marks.
+                    Optional. Must be 1-255 characters long if not left empty. Can contain letters, numbers, spaces, and punctuation marks.
                 </small>
             </div>
             <div class="mb-3">
@@ -96,7 +96,7 @@ Reference app
                 {{ form.address.label(class="form-label") }}
                 {{ form.address(class="form-control") }}
                 <small id="addressHelpInLine" class="text-muted">
-                    Optional. Must be 5-255 characters long if not left empty. Can contain letters, numbers, spaces, and punctuation marks.
+                    Optional. Must be 1-255 characters long if not left empty. Can contain letters, numbers, spaces, and punctuation marks.
                 </small>
             </div>
             <div class="mb-3">
@@ -110,14 +110,14 @@ Reference app
                 {{ form.organization.label(class="form-label") }}
                 {{ form.organization(class="form-control") }}
                 <small id="editorHelpInLine" class="text-muted">
-                    Optional. Must be 5-255 characters long if not left empty. Can contain letters, numbers, spaces, and punctuation marks.
+                    Optional. Must be 1-255 characters long if not left empty. Can contain letters, numbers, spaces, and punctuation marks.
                 </small>
             </div>
             <div class="mb-3 ">
                 {{ form.publisher.label(class="form-label") }}
                 {{ form.publisher(class="form-control") }}
                 <small id="editorHelpInLine" class="text-muted">
-                    Optional. Must be 5-255 characters long if not left empty. Can contain letters, numbers, spaces, and punctuation marks.
+                    Optional. Must be 1-255 characters long if not left empty. Can contain letters, numbers, spaces, and punctuation marks.
                 </small>
             </div>
             <br/>

--- a/src/tests/test_inproceedings_service.py
+++ b/src/tests/test_inproceedings_service.py
@@ -1,0 +1,42 @@
+import pytest
+from services.inproceedings_service import validate_inproceedings, UserInputError
+from unittest.mock import patch
+
+def test_validate_inproceedings_valid():
+    """Test that a valid inproceedings passes validation and is created."""
+    with patch("services.inproceedings_service.inproceedings_repository.create_inproceedings") as mock_create:
+        mock_create.return_value = 1
+
+        result = validate_inproceedings(
+            title="An Analysis of Example",
+            author="John Smith and Jane Doe",
+            year="2022",
+            month="June",
+            booktitle="Proceedings of the International Conference on Example",
+            publisher="ACM Press",
+            address="New York, NY",
+            series="Example Conference Proceedings",
+            volume="1",
+            number="2",
+            pages="123-130",
+            editor="David Brown and Susan Green",
+            organization="ACM"
+        )
+
+        assert result == 1
+        mock_create.assert_called_once()
+
+def test_validate_inproceedings_missing_optional_fields():
+    """Test that an inproceedings can be created without optional fields."""
+    with patch("services.inproceedings_service.inproceedings_repository.create_inproceedings") as mock_create:
+        mock_create.return_value = 1
+
+        result = validate_inproceedings(
+            title="An Analysis of Example",
+            author="John Smith and Jane Doe",
+            year="2022",
+            booktitle="Proceedings of the International Conference on Example",
+        )
+
+        assert result == 1
+        mock_create.assert_called_once()

--- a/src/validators.py
+++ b/src/validators.py
@@ -14,6 +14,12 @@ def validate_numeric(value, field_name):
     """Validates that a value is numeric."""
     if not str(value).isdigit():
         raise ValueError(f"{field_name} must be a valid number.")
+    
+def validate_common_pattern(string, name):
+    """Validates that a given string matches a common pattern of only containing letters, numbers, spaces and punctuation."""
+    pattern = r"^[a-zA-Z0-9 .,\-?!:;'()\"@]+$"
+    if not re.match(pattern, string):
+        raise ValueError(f"{name} contains invalid characters.")
 
 def validate_year(year):
     """Validates that the year is numeric and within a realistic range."""
@@ -70,3 +76,35 @@ def validate_month(month):
     ]
     if month.capitalize() not in valid_months:
         raise ValueError("Month must be a valid name or abbreviation.")
+
+def validate_booktitle(booktitle):
+    """Validates a booktitle (letters, numbers, spaces, and punctuation)."""
+    validate_length(booktitle, "Booktitle", 1, 255)
+    validate_common_pattern(booktitle, "Booktitle")
+
+def validate_series(series):
+    """Validates a series name (letters, numbers, spaces, and punctuation)."""
+    validate_length(series, "Series", 1, 255)
+    validate_common_pattern(series, "Series")
+
+def validate_address(address):
+    """Validates an address (letters, numbers, spaces, and punctuation)."""
+    validate_length(address, "Address", 1, 255)
+    validate_common_pattern(address, "Address")
+
+def validate_organization(organization):
+    """Validates an organization name (letters, numbers, spaces, and punctuation)."""
+    validate_length(organization, "Organization", 1, 255)
+    validate_common_pattern(organization, "Organization")
+    
+def validate_publisher(publisher):
+    """Validates a publisher name (letters, numbers, spaces, and punctuation)."""
+    validate_length(publisher, "Publisher", 1, 255)
+    validate_common_pattern(publisher, "Publisher")
+
+def validate_editor(editor):
+    """Validates an editor's name (letters, spaces, and dashes)."""
+    validate_length(editor, "Editor name", 2, 100)
+    pattern = r"^[a-zA-Z\- ]+$"
+    if not re.match(pattern, editor):
+        raise ValueError("Editor name can only contain letters, spaces, and dashes.")


### PR DESCRIPTION
Addressed some flaws with creating and viewing inproceedings entries.

Changes to inproceedings_repository.py:
- Editor name was missing from inproceedings entry even though it was given when creating the entry. Identified cause to be in the SQL code missing the editor value entirely when inserting values.
 
Changes to index.html:
- Editor data was not showing when viewing inproceedings entry information. Identified cause to be missing editor value row.

Changes to validators.py:
- Create dedicated validators for more inproceedings inputs. 
  - This serves to give the user better error messages instead of misleading error messages. For example, an user could have given an invalid booktitle input, but was receiving an error message for an invalid title input, leading to confusion.
  - Set length limit to 1 char for these inputs (for example, the organization name input "ACM" was not allowed previously, which caused problems)
- Create new method: validate_common_pattern() to avoid repetition within validators examining inputs with similar content.

Changes to inproceedings_service.py and inproceedings.html:
- Start utilizing added validator functionality described above.

Create test_inproceedings_service.py:
- Create basic tests for inproceedings_service.