### PR TITLE
Fix edit functionality errors

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -251,7 +251,7 @@ def add_misc():
     return render_template("misc.html", form=form)
 
 
-@app.route("/delete/<citation_type>/<int:id>", methods=["POST"])
+@app.route("/delete/<citation_type>/<int:citation_id>", methods=["POST"])
 def delete_citation(citation_type, citation_id):
     try:
         if citation_type == "article":
@@ -273,7 +273,7 @@ def delete_citation(citation_type, citation_id):
     return redirect(url_for("index"))
 
 
-@app.route("/edit/<citation_type>/<int:id>", methods=["GET", "POST"])
+@app.route("/edit/<citation_type>/<int:citation_id>", methods=["GET", "POST"])
 def edit_citation(citation_type, citation_id):
     form = None
     citation = None
@@ -303,56 +303,52 @@ def edit_citation(citation_type, citation_id):
                     form.title.data,
                     form.journal.data,
                     form.year.data,
-                    form.volume.data,
-                    form.number.data,
-                    form.pages.data,
-                    form.month.data,
-                    form.doi.data,
+                    form.volume.data if form.volume.data else None,
+                    form.number.data if form.number.data else None,
+                    form.pages.data if form.pages.data else None,
+                    form.month.data if form.month.data else None,
+                    form.doi.data if form.doi.data else None,
                 )
+
             elif citation_type == "book":
                 validate_book(
                     form.author.data,
                     form.title.data,
                     form.year.data,
-                    form.publisher.data,
-                    form.edition.data,
-                    form.pages.data,
-                    form.doi.data,
+                    form.publisher.data if form.publisher.data else None,
+                    form.edition.data if form.edition.data else None,
+                    form.pages.data if form.pages.data else None,
+                    form.doi.data if form.doi.data else None,
                 )
+
             elif citation_type == "inproceedings":
                 validate_inproceedings(
                     form.author.data,
                     form.title.data,
                     form.booktitle.data,
                     form.year.data,
-                    form.editor.data,
-                    form.volume.data,
-                    form.number.data,
-                    form.series.data,
-                    form.pages.data,
-                    form.address.data,
-                    form.month.data,
-                    form.organization.data,
-                    form.publisher.data,
+                    form.editor.data if form.editor.data else None,
+                    form.volume.data if form.volume.data else None,
+                    form.number.data if form.number.data else None,
+                    form.series.data if form.series.data else None,
+                    form.pages.data if form.pages.data else None,
+                    form.address.data if form.address.data else None,
+                    form.month.data if form.month.data else None,
+                    form.organization.data if form.organization.data else None,
+                    form.publisher.data if form.publisher.data else None,
                 )
+
             elif citation_type == "misc":
                 validate_misc(
                     form.author.data,
                     form.title.data,
                     form.year.data,
-                    form.month.data,
-                    form.howpublished.data,
-                    form.note.data,
+                    form.month.data if form.month.data else None,
+                    form.howpublished.data if form.howpublished.data else None,
+                    form.note.data if form.note.data else None,
                 )
 
-            if citation_type == "article":
-                article_repository.delete_article(citation_id)
-            elif citation_type == "book":
-                book_repository.delete_book(citation_id)
-            elif citation_type == "inproceedings":
-                inproceedings_repository.delete_inproceeding(citation_id)
-            elif citation_type == "misc":
-                misc_repository.delete_misc(citation_id)
+            delete_citation(citation_type, citation_id)
 
             flash("Reference updated successfully!", "success")
             return redirect(url_for("index"))


### PR DESCRIPTION
## Fixes to `delete_citation()` and `edit_citation()` in `app.py`

### Bug 1: Error when accessing the edit form for any citation
- Reproduction: Clicking the "edit" button for any citation resulted in an error.
- Example error message: 
  ```plaintext
  TypeError: edit_citation() got an unexpected keyword argument 'id'
  ```
- Cause: The route used `id` instead of `citation_id`, which conflicted with variable renaming in an earlier commit 
([61e240d](/matimove/miniprojekti/commit/61e240dd3b3c995fb77a54f46b3dd8d20d4978d2)).
- Fix: Updated the route to use `citation_id` consistently for both `edit_citation()` and `delete_citation()`.
- Result: Users can now access the edit form as intended.

---

### Bug 2: Error when submitting edits for citations with empty optional fields
- Reproduction: Submitting an edit for a citation with empty integer-type optional fields (e.g., `volume`) caused a database error.
- Example error message:
  ```plaintext
    sqlalchemy.exc.DataError: (psycopg2.errors.InvalidTextRepresentation) invalid input syntax for type integer: ""
    LINE 5: ...lainen', 'mahtava teksti', 'jokin lehti', '2020', '', '', ''...
  ```
- Cause: Empty form fields were submitted as empty strings (`""`), which failed validation for numeric fields.
- Fix: Modified `edit_citation()` to classify empty optional fields as `None`.
- Result: Edits with empty optional fields now submit successfully.

---

### Code improvements
- Consolidated deletion logic in `edit_citation()` by using the existing `delete_citation()` function.
