### PR TITLE
Improve validators, add a few new robottest cases

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,7 +1,6 @@
 [MASTER]
 
-ignore=tests,
-       validators.py
+ignore=tests
 
 [MESSAGE CONTROL]
 
@@ -13,6 +12,7 @@ disable=missing-module-docstring,
 	broad-exception-caught
 
 [FORMAT]
+max-line-length=120
 
 [REFACTORING]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,8 @@ disable=missing-module-docstring,
         missing-function-docstring,
         missing-class-docstring,
         unnecessary-pass,
-        f-string-without-interpolation
+        f-string-without-interpolation,
+	broad-exception-caught
 
 [FORMAT]
 

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,7 @@
 [MASTER]
 
-ignore=tests
+ignore=tests,
+       validators.py
 
 [MESSAGE CONTROL]
 

--- a/src/story_tests/add_articles.robot
+++ b/src/story_tests/add_articles.robot
@@ -27,23 +27,81 @@ Add Article With Not All Required Fields Filled
     Submit Article
     Page Should Not Contain    Article added successfully!
 
+Add Valid Article With All Inputs
+    Set Title  Toimitusketjujen Optimointi
+    Set Author  Joulupukki
+    Set Journal  Joulutiede Journal
+    Set Year  2024
+    Set Volume  1
+    Set Number  1
+    Set Pages  1-10
+    Set Month  December
+    Set Doi  10.1234/example-doi
+    Submit Article
+    Page Should Contain    Article added successfully!
+
+Add Valid Article Containing All Allowed Character Types And Multiple Authors
+    Set Title  Monien tekijöiden artikkeli
+    Set Author  Joulupukki, Joulumuori, Tonttu T. Toljanteri, Petteri Punakuono, Iso-Tonttu, Ääkkösmies Å. Öökkölä
+    Set Journal  Joulutiede Journal
+    Set Year  2024
+    Set Volume  1
+    Set Number  2
+    Set Pages  123-130
+    Set Month  December
+    Set Doi  10.1234/example-doi
+    Submit Article
+    Page Should Contain    Article added successfully!
+
+Add Real Article
+    Set Title  Implementation of the EU AI act calls for interdisciplinary governance
+    Set Author  Huixin Zhong
+    Set Journal  AI Magazine
+    Set Year  2024
+    Set Volume  45
+    Set Number  3
+    Set Pages  333-337
+    Set Month  July
+    Set Doi  10.1002/aaai.12183
+    Submit Article
+    Page Should Contain    Article added successfully!
 
 *** Keywords ***
 Set Title
       [Arguments]  ${title}
       Input Text  title  ${title}
 
-Set Author 
+Set Author
       [Arguments]  ${author}
       Input Text  author  ${author}
 
-Set Journal 
+Set Journal
       [Arguments]  ${journal}
       Input Text  journal  ${journal}
 
-Set Year 
+Set Year
       [Arguments]  ${year}
       Input Text  year  ${year}
+
+Set Volume
+      [Arguments]  ${volume}
+      Input Text  volume  ${volume}
+
+Set Number
+      [Arguments]  ${number}
+      Input Text  number  ${number}
+
+Set Pages
+      [Arguments]  ${pages}
+      Input Text  pages  ${pages}
+
+Set Month
+      [Arguments]  ${month}
+      Input Text  month  ${month}
+
+Set Doi
+      [Arguments]  ${doi}
+      Input Text  doi  ${doi}
 
 Submit Article
     Scroll Element Into view  submit

--- a/src/tests/test_article_validation.py
+++ b/src/tests/test_article_validation.py
@@ -98,7 +98,7 @@ def test_validate_article_missing_author():
 def test_validate_article_invalid_year():
     """Test that an invalid year raises UserInputError."""
     with pytest.raises(
-        UserInputError, match="Year must be a valid number between 1500 and 2100."
+        UserInputError, match="Year must be a valid number between 0 and 2100."
     ):
         validate_article(
             author="Joulupukki",

--- a/src/tests/test_misc_validation.py
+++ b/src/tests/test_misc_validation.py
@@ -58,6 +58,6 @@ def test_validate_misc_note_forbidden_characters():
 def test_validate_misc_invalid_year():
     """Test that an invalid misc title raises UserInputError."""
     with pytest.raises(
-        UserInputError, match="Year must be a valid number between 1500 and 2100."
+        UserInputError, match="Year must be a valid number between 0 and 2100."
     ):
         validate_misc(author="Kirjailija", title="Otsikko", year="3000")

--- a/src/tests/test_validators.py
+++ b/src/tests/test_validators.py
@@ -15,6 +15,16 @@ def test_validate_author_valid():
     assert validate_author("Joulupukki") is None  # Should pass without error
 
 
+def test_validate_multiple_authors_valid():
+    """Test a valid author input with multiple differing authors containing special characters, separated by commas."""
+    assert (
+        validate_author(
+            "Joulupukki, Joulumuori, Tonttu T. Toljanteri, Petteri Punakuono, Iso-Tonttu, Ääkkösmies Öökkölä"
+        )
+        is None
+    )  # Should pass without error
+
+
 def test_validate_author_invalid():
     """Test an invalid author."""
     with pytest.raises(
@@ -23,7 +33,8 @@ def test_validate_author_invalid():
         validate_author("j")  # Too short
 
     with pytest.raises(
-        ValueError, match="Author name can only contain letters, spaces, and dashes."
+        ValueError,
+        match="Author name can only contain letters, spaces, dashes, commas, periods, and Finnish characters.",
     ):
         validate_author("Joulupukki123")  # Contains invalid characters
 
@@ -32,6 +43,13 @@ def test_validate_title_valid():
     """Test a valid title."""
     assert (
         validate_title("Toimitusketjujen optimointi") is None
+    )  # Should pass without error
+
+
+def test_validate_title_with_finnish_characters_valid():
+    """Test a valid title."""
+    assert (
+        validate_title("Ääkköstitle: Plussana ruotsalainen Å") is None
     )  # Should pass without error
 
 
@@ -68,7 +86,7 @@ def test_validate_year_valid():
 def test_validate_year_invalid():
     """Test an invalid year."""
     with pytest.raises(
-        ValueError, match="Year must be a valid number between 1500 and 2100."
+        ValueError, match="Year must be a valid number between 0 and 2100."
     ):
         validate_year("abcd")  # Non-numeric
 

--- a/src/validators.py
+++ b/src/validators.py
@@ -3,7 +3,7 @@ import re
 
 def validate_required_field(value, field_name):
     """Ensures that a required field is not empty or just whitespace."""
-    if not value or not value.strip():
+    if not value or (isinstance(value, str) and not value.strip()):
         raise ValueError(f"{field_name} is required.")
 
 
@@ -30,29 +30,37 @@ def validate_common_pattern(string, name):
 
 def validate_year(year):
     """Validates that the year is numeric and within a realistic range."""
-    if not year.isdigit() or not 1500 <= int(year) <= 2100:
-        raise ValueError("Year must be a valid number between 1500 and 2100.")
+    if isinstance(year, str):
+        if not year.isdigit() or not 0 <= int(year) <= 2100:
+            raise ValueError("Year must be a valid number between 0 and 2100.")
+    elif isinstance(year, int):
+        if not 1500 <= year <= 2100:
+            raise ValueError("Year must be a valid number between 0 and 2100.")
+    else:
+        raise ValueError("Year must be a valid number between 0 and 2100.")
 
 
 def validate_author(author):
-    """Validates an author's name (letters, spaces, and dashes)."""
-    pattern = r"^[a-zA-Z\- ]+$"
+    """Validates an author's name (or multiple names) (letters, spaces, dashes, commas, periods, and Finnish characters)."""
+    pattern = r"^[a-zA-ZäöåÄÖÅ.,\- ]+$"
     if not re.match(pattern, author):
-        raise ValueError("Author name can only contain letters, spaces, and dashes.")
+        raise ValueError(
+            "Author name can only contain letters, spaces, dashes, commas, periods, and Finnish characters."
+        )
+
     validate_length(author, "Author name", 2, 100)
 
 
 def validate_title(title):
-    """Validates an article title (letters, numbers, spaces, and punctuation)."""
+    """Validates a title (letters, numbers, spaces, punctuation, and Finnish characters)."""
     validate_length(title, "Title", 5, 255)
-    pattern = r"^[a-zA-Z0-9 .,\-?!:;'()\"@]+$"
+    pattern = r"^[a-zA-ZäöåÄÖÅ0-9 .,\-?!:;'()\"@]+$"
     if not re.match(pattern, title):
         raise ValueError("Title contains invalid characters.")
 
 
 def validate_journal(journal):
     """Validates a journal name (letters, numbers, spaces, and punctuation)."""
-    validate_required_field(journal, "Journal")
     validate_length(journal, "Journal", 2, 255)
     pattern = r"^[a-zA-Z0-9 .,\-:]+$"
     if not re.match(pattern, journal):

--- a/src/validators.py
+++ b/src/validators.py
@@ -41,7 +41,7 @@ def validate_year(year):
 
 
 def validate_author(author):
-    """Validates an author's name (or multiple names) (letters, spaces, dashes, commas, periods, and Finnish characters)."""
+    """Validates author name(s) (letters, spaces, dashes, commas, periods, and Finnish characters)."""
     pattern = r"^[a-zA-ZäöåÄÖÅ.,\- ]+$"
     if not re.match(pattern, author):
         raise ValueError(


### PR DESCRIPTION
Improvements to validators. 
- validate_required_field and validate_year now account for int inputs properly.
- validate_year allows a wider year range from 0 to 2100. 
- validate_author now allows inputs containing commas (e.g. for multiple authors divided by commas), periods (e.g. for initials), and finnish characters. 
- validate_title also allows finnish characters. 
- Removed unnecessary validate_required_field method call from validate_journal as this call should be done by citation_service, not validators.

Adjusted tests that use these validators accordingly.

Also added a few new robottest cases for article entries to test expanded validator functionality.